### PR TITLE
Cleanup code, use interfaces instead of methods throwing exceptions

### DIFF
--- a/src/transformers/ImageStyleTransformer.php
+++ b/src/transformers/ImageStyleTransformer.php
@@ -5,7 +5,6 @@ namespace Phabalicious\Scaffolder\Transformers;
 use Phabalicious\Method\TaskContextInterface;
 use Phabalicious\Scaffolder\Transformers\Utils\PlaceholderService;
 use Phabalicious\Utilities\Utilities;
-use Symfony\Component\Yaml\Yaml;
 
 class ImageStyleTransformer extends YamlTransformer implements DataTransformerInterface
 {

--- a/src/transformers/Utils/Base.php
+++ b/src/transformers/Utils/Base.php
@@ -2,25 +2,37 @@
 
 namespace Phabalicious\Scaffolder\Transformers\Utils;
 
-use Phabalicious\Method\TaskContextInterface;
-use Phabalicious\Scaffolder\Transformers\Utils\ConfigAccumulator;
-use Phabalicious\Scaffolder\Transformers\Utils\PlaceholderService;
-use Phabalicious\Utilities\Utilities;
-use Phabalicious\Scaffolder\Transformers\Utils\EntityForm;
-
-abstract class Base
+abstract class Base implements BaseInterface
 {
 
     protected $template = [];
 
+    /**
+     * @var \Phabalicious\Scaffolder\Transformers\Utils\PlaceholderService
+     */
     protected $placeholderService;
 
+    /**
+     * @var \Phabalicious\Scaffolder\Transformers\Utils\ConfigAccumulator
+     */
     protected $configAccumulator;
 
     protected $data = [];
 
-    public function __construct(ConfigAccumulator $config_accumulator, PlaceholderService $placeholder_service, $data)
-    {
+    /**
+     * Base constructor.
+     *
+     * @param \Phabalicious\Scaffolder\Transformers\Utils\ConfigAccumulator $config_accumulator
+     * @param \Phabalicious\Scaffolder\Transformers\Utils\PlaceholderService $placeholder_service
+     * @param array $data
+     *
+     * @throws \Phabalicious\Scaffolder\Transformers\Utils\UnknownScaffoldTypeException
+     */
+    public function __construct(
+        ConfigAccumulator $config_accumulator,
+        PlaceholderService $placeholder_service,
+        array $data
+    ) {
         $this->template = PlaceholderService::parseTemplateFile($this->getTemplateFile());
         $this->configAccumulator = $config_accumulator;
         $this->placeholderService = $placeholder_service;
@@ -28,52 +40,45 @@ abstract class Base
     }
 
     /**
-     * {@inheritDoc}
+     * Get template file.
      */
-    protected function getTemplateFile()
+    protected function getTemplateFile(): string
     {
         return $this->getTemplateDir() . '/' . $this->getTemplateFileName();
     }
 
-    /**
-     * Get the corresponding template file name relative to template directory.
-     */
-    protected function getTemplateFileName()
-    {
-        throw new \Exception('getTemplateFileName method not implemented.');
-    }
 
     /**
-     * {@inheritDoc}
+     * Get template dir.
      */
-    protected function getTemplateDir()
+    protected function getTemplateDir(): string
     {
         return __DIR__ . '/templates';
     }
 
     /**
-     * {@inheritDoc}
+     * Get configurations.
      */
-    public function getConfigurations()
+    public function getConfigurations(): array
     {
         return $this->configAccumulator->get();
     }
 
-    public function getDependencies()
+    public function getDependencies(): array
     {
         return [];
     }
 
-    protected function getTemplateOverrideData()
+    protected function getTemplateOverrideData(): array
     {
         // @TODO Fill $data with existing template data.
         $data = $this->data;
         $out = [];
-        $manddatory_keys_map = [
-        'id' => 'id',
-        'label' => 'label',
+        $mandatory_key_names = [
+            'id' => 'id',
+            'label' => 'label',
         ];
-        foreach ($manddatory_keys_map as $key => $target) {
+        foreach ($mandatory_key_names as $key => $target) {
             $out[$key] = $data[$target];
         }
         $optional_keys_map = [

--- a/src/transformers/Utils/BaseInterface.php
+++ b/src/transformers/Utils/BaseInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Phabalicious\Scaffolder\Transformers\Utils;
+
+interface BaseInterface
+{
+    public function getTemplateFileName(): string;
+}

--- a/src/transformers/Utils/BlockContentEntity.php
+++ b/src/transformers/Utils/BlockContentEntity.php
@@ -2,17 +2,15 @@
 
 namespace Phabalicious\Scaffolder\Transformers\Utils;
 
-use Phabalicious\Scaffolder\Transformers\Utils\EntityBase;
-
 class BlockContentEntity extends EntityBase
 {
 
-    public function getEntityType()
+    public function getEntityType(): string
     {
         return 'block_content';
     }
 
-    public function getDependencies()
+    public function getDependencies(): array
     {
         return [
             'module' => [

--- a/src/transformers/Utils/ConfigAccumulator.php
+++ b/src/transformers/Utils/ConfigAccumulator.php
@@ -2,10 +2,6 @@
 
 namespace Phabalicious\Scaffolder\Transformers\Utils;
 
-use Phabalicious\Utilities\Utilities;
-use Phabalicious\Scaffolder\Transformers\Utils\PlaceholderService;
-use \Symfony\Component\Yaml\Yaml;
-
 class ConfigAccumulator
 {
 
@@ -16,7 +12,7 @@ class ConfigAccumulator
         $this->config = [];
     }
 
-    public function get()
+    public function get(): array
     {
         $config = $this->getRaw();
         $output = [];
@@ -33,7 +29,7 @@ class ConfigAccumulator
         return $output;
     }
 
-    public function getRaw()
+    public function getRaw(): array
     {
         return $this->config;
     }

--- a/src/transformers/Utils/EntityBase.php
+++ b/src/transformers/Utils/EntityBase.php
@@ -3,32 +3,16 @@
 namespace Phabalicious\Scaffolder\Transformers\Utils;
 
 use Phabalicious\Exception\ValidationFailedException;
-use Phabalicious\Method\TaskContextInterface;
-use Phabalicious\Scaffolder\Transformers\Utils\FieldWidget;
 use Phabalicious\Utilities\Utilities;
-use Phabalicious\Scaffolder\Transformers\Utils\ConfigAccumulator;
-use Phabalicious\Scaffolder\Transformers\Utils\PlaceholderService;
-use Phabalicious\Scaffolder\Transformers\Utils\Base;
-use Phabalicious\Scaffolder\Transformers\Utils\EntityForm;
-use Phabalicious\Scaffolder\Transformers\Utils\FieldField;
-use Phabalicious\Scaffolder\Transformers\Utils\FieldStorage;
 use Phabalicious\Validation\ValidationErrorBag;
 use Phabalicious\Validation\ValidationService;
 
-abstract class EntityBase extends Base
+abstract class EntityBase extends Base implements EntityBaseInterface
 {
     protected $bundle;
     protected $fields = [];
 
-    public function getEntityType()
-    {
-        throw new \Exception('Missing getEntityType method in concrete class');
-    }
 
-    public function getTemplateFileName()
-    {
-        return 'entity/' . $this->getEntityType() . '.yml';
-    }
 
     public function __construct(ConfigAccumulator $config_accumulator, PlaceholderService $placeholder_service, $data)
     {
@@ -55,12 +39,17 @@ abstract class EntityBase extends Base
         }
     }
 
-    public function getConfigName()
+    public function getTemplateFileName(): string
+    {
+        return 'entity/' . $this->getEntityType() . '.yml';
+    }
+
+    public function getConfigName(): string
     {
         return $this->getEntityType() . '.type.' . $this->bundle;
     }
 
-    protected function transformFields()
+    protected function transformFields(): array
     {
         $data = $this->data;
         $field_configs = [];

--- a/src/transformers/Utils/EntityBaseInterface.php
+++ b/src/transformers/Utils/EntityBaseInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+
+namespace Phabalicious\Scaffolder\Transformers\Utils;
+
+interface EntityBaseInterface
+{
+    public function getEntityType(): string;
+}

--- a/src/transformers/Utils/FieldTransformerFactory.php
+++ b/src/transformers/Utils/FieldTransformerFactory.php
@@ -2,8 +2,6 @@
 
 namespace Phabalicious\Scaffolder\Transformers\Utils;
 
-use Phabalicious\Utilities\PluginDiscovery;
-
 class FieldTransformerFactory
 {
 
@@ -42,13 +40,13 @@ class FieldTransformerFactory
     /**
      * Create all necessary transformers for a given field type.
      *
-     * @param $entity_type
+     * @param  string $entity_type
      * @param  array  $field
      * @param  array  $data
      *
      * @return FieldTransformerContainer
      */
-    public static function create($entity_type, array $field, array $data)
+    public static function create(string $entity_type, array $field, array $data)
     {
         $field['type'] = self::resolveAlias($field['type']);
         $field_base_type = self::getFieldBaseType($field['type']);
@@ -69,7 +67,7 @@ class FieldTransformerFactory
         return $classes[$field_type] ?? $classes['default'];
     }
 
-    protected static function resolveAlias($field_type)
+    protected static function resolveAlias($field_type): string
     {
 
         $base = self::getFieldBaseType($field_type);
@@ -80,13 +78,13 @@ class FieldTransformerFactory
         return $sub ? "$base/$sub" : $base;
     }
 
-    public static function getFieldBaseType(string $field_type)
+    public static function getFieldBaseType(string $field_type): string
     {
         list($base, ) = array_pad(explode('/', $field_type), 2, null);
         return $base;
     }
     
-    public static function getFieldSubType(string $field_type, $default = 'default')
+    public static function getFieldSubType(string $field_type, $default = 'default'): string
     {
         list(, $sub) = array_pad(explode('/', $field_type), 2, $default);
         return $sub;

--- a/src/transformers/Utils/ImageStyle.php
+++ b/src/transformers/Utils/ImageStyle.php
@@ -2,8 +2,6 @@
 
 namespace Phabalicious\Scaffolder\Transformers\Utils;
 
-use Phabalicious\Scaffolder\Transformers\Utils\Base;
-use Phabalicious\Scaffolder\Transformers\Utils\ImageEffect;
 use Phabalicious\Utilities\Utilities;
 
 class ImageStyle extends Base
@@ -67,7 +65,7 @@ class ImageStyle extends Base
         return $this->data['name'];
     }
 
-    protected function generateStyleName($data)
+    protected function generateStyleName($data): string
     {
         $prefix = 'esimg_';
         $width = $data['effective_width'];
@@ -82,17 +80,17 @@ class ImageStyle extends Base
         return $prefix . $name;
     }
 
-    protected function getTemplateFileName()
+    public function getTemplateFileName(): string
     {
         return 'image/style.template.yml';
     }
 
-    protected function getConfigName()
+    protected function getConfigName(): string
     {
         return 'image.style.' . $this->getName();
     }
 
-    protected function getTemplateOverrideData()
+    protected function getTemplateOverrideData(): array
     {
         // @TODO Fill $data with existing template data.
         $out = [];
@@ -102,7 +100,7 @@ class ImageStyle extends Base
         return $out;
     }
 
-    public function getDependencies()
+    public function getDependencies(): array
     {
         return $this->imageEffect->getDependencies();
     }

--- a/src/transformers/Utils/MediaEntity.php
+++ b/src/transformers/Utils/MediaEntity.php
@@ -36,12 +36,12 @@ class MediaEntity extends EntityBase
         $this->configAccumulator->setConfig($this->getConfigName(), $config);
     }
 
-    public function getEntityType()
+    public function getEntityType(): string
     {
         return 'media';
     }
 
-    public function getDependencies()
+    public function getDependencies(): array
     {
         return [
             'module' => [
@@ -50,7 +50,7 @@ class MediaEntity extends EntityBase
         ];
     }
     
-    public function getOverrideData()
+    public function getOverrideData(): array
     {
         $out = [];
         $out['source'] = $this->data['source'];

--- a/src/transformers/Utils/NodeEntity.php
+++ b/src/transformers/Utils/NodeEntity.php
@@ -3,7 +3,6 @@
 namespace Phabalicious\Scaffolder\Transformers\Utils;
 
 use Phabalicious\Exception\ValidationFailedException;
-use Phabalicious\Utilities\Utilities;
 use Phabalicious\Validation\ValidationErrorBag;
 use Phabalicious\Validation\ValidationService;
 
@@ -23,12 +22,12 @@ class NodeEntity extends EntityBase
         parent::__construct($config_accumulator, $placeholder_service, $data);
     }
 
-    public function getEntityType()
+    public function getEntityType(): string
     {
         return 'node';
     }
 
-    public function getDependencies()
+    public function getDependencies(): array
     {
         return [
             'module' => [
@@ -37,7 +36,7 @@ class NodeEntity extends EntityBase
         ];
     }
     
-    public function getTemplateOverrideData()
+    public function getTemplateOverrideData(): array
     {
         $out = parent::getTemplateOverrideData();
         $out['help'] = $this->data['help'] ?? '';

--- a/src/transformers/Utils/ParagraphEntity.php
+++ b/src/transformers/Utils/ParagraphEntity.php
@@ -2,23 +2,21 @@
 
 namespace Phabalicious\Scaffolder\Transformers\Utils;
 
-use Phabalicious\Scaffolder\Transformers\Utils\EntityBase;
-
 class ParagraphEntity extends EntityBase
 {
 
-    public function getEntityType()
+    public function getEntityType(): string
     {
         return 'paragraph';
     }
 
 
-    public function getConfigName()
+    public function getConfigName(): string
     {
         return 'paragraphs.paragraphs_type.' . $this->bundle;
     }
 
-    public function getDependencies()
+    public function getDependencies(): array
     {
         return [];
     }

--- a/src/transformers/Utils/PlaceholderService.php
+++ b/src/transformers/Utils/PlaceholderService.php
@@ -2,7 +2,6 @@
 
 namespace Phabalicious\Scaffolder\Transformers\Utils;
 
-use Phabalicious\Method\TaskContextInterface;
 use Phabalicious\Utilities\Utilities;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
@@ -37,7 +36,7 @@ class PlaceholderService
 
     protected $placeholders;
 
-    public static function createChildReference(string $key)
+    public static function createChildReference(string $key): string
     {
         static $counter = 0;
         $counter++;
@@ -59,7 +58,7 @@ class PlaceholderService
      * There's one big exception. If a subkey is numerig it will also lookup the nth element in that array, regardless
      * of the key.
      *
-     * @param $data
+     * @param array $data
      *   The array.
      * @param string $key
      *   A key for the wnated value. Dots will separate hierachylevels. eg. root.level1.level2.level3.value
@@ -68,7 +67,7 @@ class PlaceholderService
      * @return mixed
      *   the found value.
      */
-    public static function lookupValue($data, string $key, $default_value = null)
+    public static function lookupValue(array $data, string $key, $default_value = null)
     {
         $value = $default_value;
         $keys = explode('.', $key);
@@ -101,13 +100,13 @@ class PlaceholderService
         return $value;
     }
 
-    public static function createAbsoluteReuseReference(array $keys)
+    public static function createAbsoluteReuseReference(array $keys): string
     {
         return self::CREATE_OR_REUSE_ABSOLUTE_REFERENCE . "|" . implode(".", $keys);
     }
 
 
-    public function postTransform($items, $target_path)
+    public function postTransform($items, $target_path): array
     {
         $return = [];
         foreach ($items as $file => $results) {
@@ -125,7 +124,7 @@ class PlaceholderService
         return $return;
     }
 
-    protected function postTransformValues($values, $existing, $existing_haystack)
+    protected function postTransformValues($values, $existing, $existing_haystack): array
     {
         $results = [];
         foreach ($values as $key => $value) {
@@ -190,13 +189,13 @@ class PlaceholderService
     /**
      * Decode the placeholder strategy and parameters in the given key.
      *
-     * @param $key
+     * @param mixed $key
      *  Array key.
      *
      * @return array
      *  An array with strategy as first item, followed by parameters.
      */
-    private function getPlaceholderStrategyForKey($key)
+    private function getPlaceholderStrategyForKey($key): array
     {
         $values = explode('|', $key);
         // Probably the case when $key doesn't have a strategy mentioned.
@@ -217,15 +216,15 @@ class PlaceholderService
     /**
      * Replace values base don encoded strategy in array keys.
      *
-     * @param $values
+     * @param array $values
      *  Incoming values.
-     * @param $existing
+     * @param array $existing
      *  Values in existing configuration.
      *
      * @return mixed
      *  Adjusted values after corresponding replacement strategy has been done.
      */
-    private function adjustValuesFromExistingConfig($values, $existing)
+    private function adjustValuesFromExistingConfig(array $values, array $existing)
     {
         $values_copy = $values;
         // Traverse over each high level keys and prepare

--- a/src/transformers/Utils/Plugins/CtaFieldFormatter.php
+++ b/src/transformers/Utils/Plugins/CtaFieldFormatter.php
@@ -3,14 +3,13 @@
 
 namespace Phabalicious\Scaffolder\Transformers\Utils\Plugins;
 
-use Phabalicious\Scaffolder\Transformers\Utils\FieldField;
 use Phabalicious\Scaffolder\Transformers\Utils\FieldFormatter;
 use Phabalicious\Utilities\Utilities;
 
 class CtaFieldFormatter extends FieldFormatter
 {
 
-    protected function getTemplateOverrideData()
+    protected function getTemplateOverrideData(): array
     {
         return Utilities::mergeData(
             parent::getTemplateOverrideData(),

--- a/src/transformers/Utils/Plugins/EntityReferenceFieldField.php
+++ b/src/transformers/Utils/Plugins/EntityReferenceFieldField.php
@@ -5,7 +5,6 @@ namespace Phabalicious\Scaffolder\Transformers\Utils\Plugins;
 
 use Phabalicious\Exception\ValidationFailedException;
 use Phabalicious\Scaffolder\Transformers\Utils\FieldField;
-use Phabalicious\Utilities\Utilities;
 use Phabalicious\Validation\ValidationErrorBag;
 use Phabalicious\Validation\ValidationService;
 
@@ -22,7 +21,7 @@ class EntityReferenceFieldField extends FieldField
         }
     }
 
-    protected function getTemplateOverrideData()
+    protected function getTemplateOverrideData(): array
     {
         $data = parent::getTemplateOverrideData();
 

--- a/src/transformers/Utils/ResponsiveImage.php
+++ b/src/transformers/Utils/ResponsiveImage.php
@@ -2,8 +2,6 @@
 
 namespace Phabalicious\Scaffolder\Transformers\Utils;
 
-use Phabalicious\Scaffolder\Transformers\Utils\Base;
-use Phabalicious\Scaffolder\Transformers\Utils\ImageEffect;
 use Phabalicious\Utilities\Utilities;
 
 class ResponsiveImage extends Base
@@ -77,17 +75,17 @@ class ResponsiveImage extends Base
         $this->configAccumulator->setConfig($this->getConfigName(), $config);
     }
 
-    public function getTemplateFileName()
+    public function getTemplateFileName(): string
     {
         return 'image/responsive_image.styles.template.yml';
     }
 
-    public function getConfigName()
+    public function getConfigName(): string
     {
         return 'responsive_image.styles.'.$this->data['id'];
     }
 
-    public function getTemplateOverrideData()
+    public function getTemplateOverrideData(): array
     {
         $data = parent::getTemplateOverrideData();
         $data['breakpoint_group'] = $this->data['breakpoint_group'];

--- a/tests/BaseScaffoldingTest.php
+++ b/tests/BaseScaffoldingTest.php
@@ -7,7 +7,6 @@ use Phabalicious\Configuration\ConfigurationService;
 use Phabalicious\Method\MethodFactory;
 use Phabalicious\Method\ScriptMethod;
 use Phabalicious\Utilities\Utilities;
-use PHPUnit\Framework\Exception;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Application;

--- a/tests/BlockContentTest.php
+++ b/tests/BlockContentTest.php
@@ -3,7 +3,6 @@
 namespace Phabalicious\Scaffolder\Tests;
 
 use Symfony\Component\Console\Tester\CommandTester;
-use Symfony\Component\Yaml\Yaml;
 
 class BlockContentTest extends BaseScaffoldingTest
 {


### PR DESCRIPTION
hi @d34dman 

This PR will only do some code cleanup, and removing empty emthods which throw an exception and replacing them with an interface. This has a better DX as your editor will mark the subclass as faulty as it does not implement the interface completely.

No functional changes besides that.